### PR TITLE
Optional autocomplete of relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ The main class `Neo4jGraphWidget` provides the following API:
     - `**kwargs`: Additional parameters that should be passed to the cypher query (e.g., see
       the [selection example](https://github.com/yWorks/yfiles-jupyter-graphs-for-neo4j/blob/main/examples/selection_example.ipynb)).
 
+The default behavior is to only show the nodes and relationships returned by the cypher query.
+This can be changed to autocomplete relationships like in neo4j browser:
+- `set_autocomplete_relationships(autocomplete_relationships)`: Sets whether to autocomplete relationships in the graph or not.
+
 The cypher queries are executed by the provided Neo4j driver. If you have not specified a driver when instantiating the
 class, you can set
 a driver afterward:

--- a/src/yfiles_jupyter_graphs_for_neo4j/Yfiles_Neo4j_Graphs.py
+++ b/src/yfiles_jupyter_graphs_for_neo4j/Yfiles_Neo4j_Graphs.py
@@ -18,7 +18,8 @@ class Neo4jGraphWidget:
     _widget = GraphWidget()
 
     def __init__(self, driver=None, widget_layout=None,
-                 overview_enabled=None, context_start_with='About', license=None):
+                 overview_enabled=None, context_start_with='About', license=None,
+                 autocomplete_relationships=False):
         if driver is not None:
             self._driver = driver
         self._session = driver.session()
@@ -26,7 +27,7 @@ class Neo4jGraphWidget:
         self._overview = overview_enabled
         self._layout = widget_layout
         self._context_start_with = context_start_with
-        self._autocomplete_relationships = False
+        self.set_autocomplete_relationships(autocomplete_relationships)
 
     def set_driver(self, driver):
         """
@@ -67,9 +68,7 @@ class Neo4jGraphWidget:
         return len(self._autocomplete_relationships) > 0
 
     def _get_relationship_types_expression(self):
-        if self._autocomplete_relationships == True:
-            return ""
-        elif len(self._autocomplete_relationships) > 0:
+        if isinstance(self._autocomplete_relationships, list) and len(self._autocomplete_relationships) > 0:
             return "AND type(rel) IN $relationship_types"
         return ""
 

--- a/src/yfiles_jupyter_graphs_for_neo4j/Yfiles_Neo4j_Graphs.py
+++ b/src/yfiles_jupyter_graphs_for_neo4j/Yfiles_Neo4j_Graphs.py
@@ -55,7 +55,7 @@ class Neo4jGraphWidget:
         :param autocomplete_relationships: bool | str | list[str]
         """
         if not isinstance(autocomplete_relationships, (bool, str, list)):
-            raise ValueError("autocomplete_relationships must be a bool or a list of strings")
+            raise ValueError("autocomplete_relationships must be a bool, a string, or a list of strings")
         if isinstance(autocomplete_relationships, str):
             self._autocomplete_relationships = [autocomplete_relationships]
         else:


### PR DESCRIPTION
This is a simple implementation for autocompleting relationships in the graph. Solves https://github.com/yWorks/yfiles-jupyter-graphs-for-neo4j/issues/1, but it's a simple on/off switch so it does not address the part about providing a list of relationship types.